### PR TITLE
Feature/remove correct from session

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///database.db'
 api = Api(app)
 jsglue = JSGlue(app)
-database.init_app(app) # this should be in the 'if is main' at the bottom of this file so that the database isn't re-initialized if 'app.py' is imported from another file, but that would mean that the database is never initialized if we run the app via Flask instead of Python
+database.init_app(app)
 
 @app.before_first_request
 def create_tables():
@@ -70,5 +70,4 @@ api.add_resource(Quiz, '/quizzes')
 api.add_resource(Answer, '/answers')
 
 if __name__ == "__main__":
-	
 	app.run(host='127.0.0.1', debug=True)

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flask_jsglue import JSGlue
 from database import database, insert_queries
 from resources.topic import Topic
 from resources.formativeAssessment import FormativeAssessment
-from resources.test import Test
+from resources.test import Test, TestCorrectAnswers
 from resources.quiz import Quiz
 from resources.answer import Answer
 import sys
@@ -65,6 +65,7 @@ def formativeAssessment():
 api.add_resource(Topic, '/topics')
 api.add_resource(FormativeAssessment, '/formativeAssessments')
 api.add_resource(Test, '/tests')
+api.add_resource(TestCorrectAnswers, '/tests/correctAnswers')
 api.add_resource(Quiz, '/quizzes')
 api.add_resource(Answer, '/answers')
 

--- a/models/answer.py
+++ b/models/answer.py
@@ -41,11 +41,3 @@ class AnswerModel(database.Model):
     @classmethod
     def find_by_id(cls, answer_id):
         return cls.query.filter_by(answer_id=answer_id).first()
-
-    @classmethod
-    def get_all(cls):
-        return cls.query.all()
-
-    @classmethod
-    def get_all_for_quiz(cls, quiz_id):
-        return cls.query.filter_by(quiz_id=quiz_id).all()

--- a/models/answer.py
+++ b/models/answer.py
@@ -20,15 +20,19 @@ class AnswerModel(database.Model):
         self.path_to_attachment = path_to_attachment
         self.is_selected = is_selected
     
-    def json(self):
-        return {
+    def json(self, getCorrect=False):
+        answerJson = {
             'answer_id': self.answer_id,
             'quiz_id': self.quiz_id,
             'body': self.body,
-            'is_correct': self.is_correct,
             'path_to_attachment': self.path_to_attachment,
             'is_selected': self.is_selected,
         }
+
+        if getCorrect:
+            answerJson['is_correct'] = self.is_correct
+        
+        return answerJson
 
     def save_to_database(self):
         database.session.add(self)

--- a/models/answer.py
+++ b/models/answer.py
@@ -20,7 +20,7 @@ class AnswerModel(database.Model):
         self.path_to_attachment = path_to_attachment
         self.is_selected = is_selected
     
-    def json(self, getCorrect=False):
+    def json(self, getCorrectAnswers=False):
         answerJson = {
             'answer_id': self.answer_id,
             'quiz_id': self.quiz_id,
@@ -29,7 +29,7 @@ class AnswerModel(database.Model):
             'is_selected': self.is_selected,
         }
 
-        if getCorrect:
+        if getCorrectAnswers:
             answerJson['is_correct'] = self.is_correct
         
         return answerJson

--- a/models/formativeAssessment.py
+++ b/models/formativeAssessment.py
@@ -58,18 +58,10 @@ class FormativeAssessmentModel(database.Model):
         database.session.add(self)
         database.session.commit()
 
-    def delete_from_database(self, query, args):
+    def delete_from_database(self):
         database.session.delete(self)
         database.session.commit()
 
     @classmethod
     def find_by_id(cls, fa_id):
         return cls.query.filter_by(fa_id=fa_id).first()
-
-    @classmethod
-    def get_all(cls):
-        return cls.query.all()
-
-    @classmethod
-    def get_all_for_topic(cls, topic_id):
-        return cls.query.filter_by(topic_id=topic_id).all()

--- a/models/quiz.py
+++ b/models/quiz.py
@@ -48,18 +48,10 @@ class QuizModel(database.Model):
         database.session.add(self)
         database.session.commit()
 
-    def update_db(self):
+    def delete_from_database(self):
         database.session.delete(self)
         database.session.commit()
 
     @classmethod
     def find_by_id(cls, quiz_id):
         return cls.query.filter_by(quiz_id=quiz_id).first()
-
-    @classmethod
-    def get_all(cls):
-        return cls.query.all()
-
-    @classmethod
-    def get_all_for_test(cls, test_id):
-        return cls.query.filter_by(test_id=test_id).all()

--- a/models/quiz.py
+++ b/models/quiz.py
@@ -52,6 +52,9 @@ class QuizModel(database.Model):
         database.session.delete(self)
         database.session.commit()
 
+    def get_correct_answer(self):
+        return self.answers.filter_by(quiz_id=self.quiz_id, is_correct=True).first()
+
     @classmethod
     def find_by_id(cls, quiz_id):
         return cls.query.filter_by(quiz_id=quiz_id).first()

--- a/models/quiz.py
+++ b/models/quiz.py
@@ -29,7 +29,7 @@ class QuizModel(database.Model):
         self.title = title
         self.instructions = instructions
     
-    def json(self):
+    def json(self, getCorrectAnswers=False):
         return {
             'quiz_id': self.quiz_id,
             'test_id': self.test_id,
@@ -41,7 +41,7 @@ class QuizModel(database.Model):
             'path_to_attachment': self.path_to_attachment,
             'title': self.title,
             'instructions': self.instructions,
-            'answers': [a.json() for a in self.answers.all()]
+            'answers': [a.json(getCorrectAnswers=getCorrectAnswers) for a in self.answers.all()]
         }
 
     def save_to_database(self):

--- a/models/test.py
+++ b/models/test.py
@@ -58,11 +58,3 @@ class TestModel(database.Model):
     @classmethod
     def find_by_id(cls, test_id):
         return cls.query.filter_by(test_id=test_id).first()
-
-    @classmethod
-    def get_all(cls):
-        return cls.query.all()
-
-    @classmethod
-    def get_all_for_topic(cls, topic_id):
-        return cls.query.filter_by(topic_id=topic_id).all()

--- a/models/test.py
+++ b/models/test.py
@@ -31,7 +31,7 @@ class TestModel(database.Model):
         self.is_retakeable = is_retakeable
         self.is_official = is_official
     
-    def json(self):
+    def json(self, getCorrectAnswers=False):
         return {
             'test_id': self.test_id,
             'topic_id': self.topic_id,
@@ -44,7 +44,7 @@ class TestModel(database.Model):
             'description': self.description,
             'is_retakeable': self.is_retakeable,
             'is_official': self.is_official,
-            'quizzes': [q.json() for q in self.quizzes.all()]
+            'quizzes': [q.json(getCorrectAnswers=getCorrectAnswers) for q in self.quizzes.all()]
         }
 
     def save_to_database(self):
@@ -62,7 +62,7 @@ class TestModel(database.Model):
             answer = q.get_correct_answer()
 
             if answer:
-                answer = answer.json(getCorrect=True)
+                answer = answer.json(getCorrectAnswers=True)
                 
             correctAnswers.append(answer)
 

--- a/models/test.py
+++ b/models/test.py
@@ -55,6 +55,19 @@ class TestModel(database.Model):
         database.session.delete(self)
         database.session.commit()
 
+    def get_correct_answers(self):
+        correctAnswers = []
+
+        for q in self.quizzes.all():
+            answer = q.get_correct_answer()
+
+            if answer:
+                answer = answer.json(getCorrect=True)
+                
+            correctAnswers.append(answer)
+
+        return correctAnswers
+
     @classmethod
     def find_by_id(cls, test_id):
         return cls.query.filter_by(test_id=test_id).first()

--- a/models/test.py
+++ b/models/test.py
@@ -62,7 +62,7 @@ class TestModel(database.Model):
             answer = q.get_correct_answer()
 
             if answer:
-                answer = answer.json(getCorrectAnswers=True)
+                answer = answer.answer_id
                 
             correctAnswers.append(answer)
 

--- a/models/topic.py
+++ b/models/topic.py
@@ -32,6 +32,10 @@ class TopicModel(database.Model):
         database.session.add(self)
         database.session.commit()
 
+    def delete_from_database(self):
+        database.session.delete(self)
+        database.session.commit()
+
     @classmethod
     def find_by_id(cls, topic_id):
         return cls.query.filter_by(topic_id=topic_id).first()

--- a/resources/test.py
+++ b/resources/test.py
@@ -89,3 +89,10 @@ class Test(Resource):
             test.delete_from_database()
 
         return {'message': 'Test with ID {} deleted.'.format(request_data['test_id'])}, 200
+
+class TestCorrectAnswers(Resource):
+    def get(self):
+        request_data = Test.parser.parse_args()
+        test = TestModel.find_by_id(request_data['test_id'])
+
+        return {'correctAnswers': test.get_correct_answers()}

--- a/resources/test.py
+++ b/resources/test.py
@@ -19,6 +19,7 @@ class Test(Resource):
     parser.add_argument('description', type=str)
     parser.add_argument('is_retakeable', type=bool)
     parser.add_argument('is_official', type=bool)
+    parser.add_argument('get_correct_answers', type=bool)
 
     def get(self):
         request_data = Test.parser.parse_args()
@@ -29,7 +30,7 @@ class Test(Resource):
             return {'message': 'An error occurred while reading the test ID from the database'}, 500
         
         if test:
-            return test.json()
+            return test.json(getCorrectAnswers=request_data['get_correct_answers'])
         return {'message': 'Test with the ID {} not found'.format(request_data['test_id'])}, 404
     
     def put(self):
@@ -38,7 +39,19 @@ class Test(Resource):
         
         try:
             if not test:
-                test = TestModel(**request_data)
+                test = TestModel(
+                    request_data['test_id'],
+                    request_data['topic_id'],
+                    request_data['is_unlocked'],
+                    request_data['max_credit'],
+                    request_data['order_num'],
+                    request_data['gained_credit'],
+                    request_data['pass_credit'],
+                    request_data['time_limit'],
+                    request_data['description'],
+                    request_data['is_retakeable'],
+                    request_data['is_official']
+                )
             else: # if 'test' is defined, this means there's an existing record under this ID, so update it with the values we have
                 if request_data['test_id'] != None:
                     test.test_id = request_data['test_id']

--- a/templates/test-result.html
+++ b/templates/test-result.html
@@ -3,7 +3,7 @@
 {% block content %}
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<script>
-		request.ajax({endpoint: 'tests', data: {test_id: storageUtils.getSessionValue(storageUtils.testID)}, handler: requestHandlers.displayResults});
+		request.ajax({endpoint: 'tests', data: {test_id: storageUtils.getSessionValue(storageUtils.testID), get_correct_answers: true}, handler: requestHandlers.displayResults});
 	</script>
 
 	<div class="grid-container container-with-top-pad">


### PR DESCRIPTION
- There is now no 'is_correct' stored in the session storage without requesting it: it's still used during the results page so it's required.
- New resource '/tests/correctAnswers' which returns a list of the correct answers' ID.
- Also @McPenquen, the redirection of the user to the results page by clicking 'Finish' doesn't appear to need a timeout anymore as it's been moved to the end of the requestHandler of the 'Finish' button (it's commented out as of now - I thought I'd let you try it as well before merging).